### PR TITLE
Add variable {{REPO1_URL}} to SLES 12 basic test

### DIFF
--- a/aytests/sles12.vars
+++ b/aytests/sles12.vars
@@ -1,0 +1,1 @@
+REPO1_URL=http://{{IP}}:{{PORT}}/static/repos/sles12

--- a/aytests/sles12.xml
+++ b/aytests/sles12.xml
@@ -4,7 +4,7 @@
   <add-on>
     <add_on_products config:type="list">
       <listentry>
-        <media_url><![CDATA[http://%IP%:8888/static/repos/sles12]]></media_url>
+        <media_url><![CDATA[{{REPO1_URL}}]]></media_url>
         <product>custom</product>
         <product_dir>/</product_dir>
         <name>Customized</name>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Dec 21 09:03:08 UTC 2015 - igonzalezsosa@suse.com
+
+- Replaces %IP% for {{REPO1_URL}} variable in sles12.rb test.
+
+-------------------------------------------------------------------
 Mon Dec 14 14:44:22 UTC 2015 - igonzalezsosa@suse.com
 
 - Initial version

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.0.0
+Version:        1.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -29,6 +29,9 @@ Summary:        Integration tests for AutoYaST2
 License:        GPL-3.0
 Group:          System/YaST
 Url:            https://github.com/yast/aytests-tests
+
+# Depends on .vars files mechanism.
+Requires:       aytests >= 1.0.1
 
 %description
 Profiles and test scripts for AutoYaST2 integration tests.


### PR DESCRIPTION
This commit replaces the old mechanism to have variables in templates (%IP%) for the [the new one](https://github.com/yast/autoyast-integration-test/pull/75).
