### PR TITLE
Dependency on aytests is not mandatory anymore

### DIFF
--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,7 +1,14 @@
 -------------------------------------------------------------------
+Tue Dec 22 00:50:05 UTC 2015 - igonzalezsosa@suse.com
+
+- Dependency on aytests is not mandatory anymore.
+- Version 1.0.2
+
+-------------------------------------------------------------------
 Mon Dec 21 09:03:08 UTC 2015 - igonzalezsosa@suse.com
 
 - Replaces %IP% for {{REPO1_URL}} variable in sles12.rb test.
+- Version 1.0.1
 
 -------------------------------------------------------------------
 Mon Dec 14 14:44:22 UTC 2015 - igonzalezsosa@suse.com

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.0.1
+Version:        1.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -31,7 +31,7 @@ Group:          System/YaST
 Url:            https://github.com/yast/aytests-tests
 
 # Depends on .vars files mechanism.
-Requires:       aytests >= 1.0.1
+Recommends:     aytests >= 1.0.1
 
 %description
 Profiles and test scripts for AutoYaST2 integration tests.


### PR DESCRIPTION
This is needed for SLEPOS guys and, anyway, it makes sense.
