### PR TITLE
Report unsupported and obsolete sections

### DIFF
--- a/aytests/report_obsolete_sections.sh
+++ b/aytests/report_obsolete_sections.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Check that obsolete sections are not supported.
+#
+set -e -x
+
+grep -Pzq "These sections of AutoYaST profile are not supported anymore:\n\n<sshd\/>\n\n" \
+  /var/log/YaST2/y2log && echo "AUTOYAST OK"

--- a/aytests/report_unsupported_sections.sh
+++ b/aytests/report_unsupported_sections.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Check that unsupported sections cannot be processed.
+#
+set -e -x
+
+grep -Pzq "These sections of AutoYaST profile cannot be processed on this system:\n\n<unsupported\/>\n\n" \
+  /var/log/YaST2/y2log && echo "AUTOYAST OK"

--- a/aytests/sles12.list
+++ b/aytests/sles12.list
@@ -17,5 +17,5 @@ ifcfg_networking.sh            # configures network interfaces (bsc#949193)
 restart_services.sh            # do no restart dbus and wickedd* services (bsc#944349)
 init_script.sh		       # download and execute init scripts (bnc#961320)
 check_schema.sh                # check generated AutoYaST profile (bsc#954412)
-report_unsupported_sections.sh # report unsupported sections
-report_obsolete_sections.sh    # report obsolete sections
+report_unsupported_sections.sh # report unsupported sections (bsc#925381)
+report_obsolete_sections.sh    # report obsolete sections (bsc#925381)

--- a/aytests/sles12.list
+++ b/aytests/sles12.list
@@ -17,3 +17,5 @@ ifcfg_networking.sh            # configures network interfaces (bsc#949193)
 restart_services.sh            # do no restart dbus and wickedd* services (bsc#944349)
 init_script.sh		       # download and execute init scripts (bnc#961320)
 check_schema.sh                # check generated AutoYaST profile (bsc#954412)
+report_unsupported_sections.sh # report unsupported sections
+report_obsolete_sections.sh    # report obsolete sections

--- a/aytests/sles12.xml
+++ b/aytests/sles12.xml
@@ -709,7 +709,7 @@ ls -l /mnt/$BASE
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">5</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>
@@ -719,7 +719,7 @@ ls -l /mnt/$BASE
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">5</timeout>
     </warnings>
     <yesno_messages>
       <log config:type="boolean">true</log>
@@ -828,4 +828,30 @@ ls -l /mnt/$BASE
       <username>root</username>
     </user>
   </users>
+
+  <install>
+     <init>
+       <info_file>
+<![CDATA[
+#
+# Do not remove the following line:
+# start_linuxrc_conf
+#
+textmode: 1
+linuxrc.debug=1
+
+# end_linuxrc_conf
+# Do not remove the above comment
+#
+]]>
+      </info_file>
+    </init>
+  </install>
+  <unsupported>
+    <comment>This is a dummy and also unsupported section</comment>
+  </unsupported>
+
+  <sshd>
+    <comment>This is an obsolete section</comment>
+  </sshd>
 </profile>

--- a/aytests/sles12.xml
+++ b/aytests/sles12.xml
@@ -709,6 +709,7 @@ ls -l /mnt/$BASE
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
+      <!-- We expect error messages during installation. We will 'grep' for them. -->
       <timeout config:type="integer">5</timeout>
     </errors>
     <messages>
@@ -719,6 +720,7 @@ ls -l /mnt/$BASE
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
+      <!-- We expect warnings during installation. We will 'grep' for them. -->
       <timeout config:type="integer">5</timeout>
     </warnings>
     <yesno_messages>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 20 11:05:53 UTC 2016 - igonzalezsosa@suse.com
+
+- Add tests to check that obsolete and unsupported sections
+  are reported to the user (bsc#962526).
+- Version 1.0.7
+
+-------------------------------------------------------------------
 Tue Jan 19 10:32:19 UTC 2016 - igonzalezsosa@suse.com
 
 - Add tests to check the schema that was generated during

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.0.6
+Version:        1.0.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
I'm adding a test to check that unsupported/obsolete versions are reported to the user. BTW, I'd consider removing https://github.com/yast/aytests-tests/blob/master/aytests/tftp.list#L3 (as it looks redundant). Checking that `autofs`, `sshd` and `restore` are obsolete could be done in unit tests.
