### PR TITLE
Add a test to check minimalistic_libzypp_config option

### DIFF
--- a/aytests/default.list
+++ b/aytests/default.list
@@ -10,3 +10,4 @@ append_kernel.sh               # append arguments to kernel configuration (relat
 btrfs_set_subvol_default_name.sh  # default subvolume name is set (FATE#317775)
 btrfs_copy_on_write_subvolumes.sh # Set copy-on-write options in Btrfs subvolumes (FATE#320342)
 no_second_stage.sh             # second stage is not available (bsc#1022267)
+minimalistic_libzypp_config.sh # libzypp minimalistic configuration (FATE#321764)

--- a/aytests/minimalistic_libzypp_config.sh
+++ b/aytests/minimalistic_libzypp_config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e -x
+
+# Check if libzypp configuration is suitable for a minimalistic system:
+# only required packages, no documentation and no multiversion.
+# (FATE#321764)
+
+LIBZYPP_CONF=/etc/zypp/zypp.conf
+
+grep "^solver.onlyRequires=true" $LIBZYPP_CONF
+grep "^rpm.install.excludedocs=yes" $LIBZYPP_CONF
+grep -E "^multiversion =$" $LIBZYPP_CONF
+echo "AUTOYAST OK"


### PR DESCRIPTION
This PR adds a test for `minimalistic_libzypp_config` option. We need to extend `autoyast-integration-tests` to support CASP.