### PR TITLE
CaaSP second stage

### DIFF
--- a/aytests/default.list
+++ b/aytests/default.list
@@ -9,3 +9,4 @@ set_passwords.sh               # password are set (bsc#973639, bsc#974220, bsc#9
 append_kernel.sh               # append arguments to kernel configuration (related to bsc#968192)
 btrfs_set_subvol_default_name.sh  # default subvolume name is set (FATE#317775)
 btrfs_copy_on_write_subvolumes.sh # Set copy-on-write options in Btrfs subvolumes (FATE#320342)
+no_second_stage.sh             # second stage is not available (bsc#1022267)

--- a/aytests/minimal.list
+++ b/aytests/minimal.list
@@ -2,3 +2,4 @@ user.sh                        # vagrant user has been created
 root.sh                        # root hast /root home (bnc#878427)
 ifcfg_networking.sh            # configures network interfaces (bsc#949193)
 set_passwords.sh               # password are set (bsc#973639, bsc#974220, bsc#971804 and bsc#965852)
+no_second_stage.sh             # second stage is not available (bsc#1022267)

--- a/aytests/no_second_stage.sh
+++ b/aytests/no_second_stage.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e -x
+
+# Check that the second stage is not required
+
+zgrep "It is not required to run the second stage" /var/log/YaST2/y2log-1.gz
+echo "AUTOYAST OK"

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  9 12:19:38 UTC 2017 - igonzalezsosa@suse.com
+
+- Check that the second stage was not available in CaaSP 1.0
+  (bsc#1022267)
+- 1.0.39.3
+
+-------------------------------------------------------------------
 Wed Feb  8 12:41:46 UTC 2017 - igonzalezsosa@suse.com
 
 - Add a pair of working tests for CaaSP 1.0

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.0.39.2
+Version:        1.0.39.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Adding support for CaaSP to AutoYaST integration tests

While fixing a problem with AutoYaST and CaaSP, we decided to extend our AutoYaST integration testing tool to support CaaSP. But, as a side effect, we also made some additional improvements that were long overdue (like improving the procedure to download ISOs, reducing timeouts, etc.).

Now, our internal Jenkins instance takes care of running AutoYaST integration tests for the development version of CaaSP (as it already does for SLE 12 SP2).

## Not for the blog

Test case for [bsc#1022267](https://bugzilla.novell.com/show_bug.cgi?id=1022267).