### PR TITLE
Test not downloading the release notes (bsc#1009276)

### DIFF
--- a/aytests/no_release_notes.sh
+++ b/aytests/no_release_notes.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+
+# release notes are not downloaded for AY (bsc#1009276)
+zgrep "Downloading release notes:.*curl" /var/log/YaST2/y2log-1.gz || echo "AUTOYAST OK"

--- a/aytests/sles12_network.list
+++ b/aytests/sles12_network.list
@@ -16,3 +16,4 @@ handle_zypper_pkg_gpg_check.sh # handles zypper's pkgGpgCheck callback during in
 restart_services.sh            # do no restart dbus and wickedd* services (bsc#944349)
 udev_net_rules.sh              # Check udev network rules were written (bsc#956605)
 set_passwords.sh               # password are set (bsc#973639, bsc#974220, bsc#971804 and bsc#965852)
+no_release_notes.sh            # release notes are not downloaded for AY (bsc#1009276)

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 14 12:44:38 UTC 2017 - mvidner@suse.com
+
+- Test not downloading the release notes (bsc#1009276).
+- 1.0.46
+
+-------------------------------------------------------------------
 Thu Feb 16 13:20:12 CET 2017 - schubi@suse.de
 
 - testcase: Services-manager has disabled apache2 in first AND

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.0.45
+Version:        1.0.46
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- https://trello.com/c/BmzMFKzs/853-3-12-sp3-caasp-autoyast-stop-downloading-release-notes-from-web-completely-mostly-done
- https://bugzilla.suse.com/show_bug.cgi?id=1009276