### PR TITLE
Install tar

### DIFF
--- a/aytests/sles12_mini_network.xml
+++ b/aytests/sles12_mini_network.xml
@@ -51,6 +51,8 @@
       <package>ca-certificates-mozilla</package>
       <!-- Workaround about missing glibc-locale -->
       <package>glibc-locale</package>
+      <!-- We need tar to pack logs -->
+      <package>tar</package>
     </packages>
   </software>
 

--- a/aytests/sles12_minimal.xml
+++ b/aytests/sles12_minimal.xml
@@ -33,6 +33,8 @@
       <package>ca-certificates-mozilla</package>
       <!-- Workaround about missing glibc-locale -->
       <package>glibc-locale</package>
+      <!-- We need tar to pack logs -->
+      <package>tar</package>
     </packages>
   </software>
 

--- a/aytests/sles12_minimal_network.xml
+++ b/aytests/sles12_minimal_network.xml
@@ -33,6 +33,8 @@
       <package>ca-certificates-mozilla</package>
       <!-- Workaround about missing glibc-locale -->
       <package>glibc-locale</package>
+      <!-- We need tar to pack logs -->
+      <package>tar</package>
     </packages>
   </software>
 

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr  3 13:45:07 UTC 2017 - igonzalezsosa@suse.com
+
+- Install tar in order to compress and download YaST2 logs
+- 1.0.47
+
+-------------------------------------------------------------------
 Tue Mar 14 12:44:38 UTC 2017 - mvidner@suse.com
 
 - Test not downloading the release notes (bsc#1009276).

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.0.46
+Version:        1.0.47
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -31,7 +31,7 @@ Group:          System/YaST
 Url:            https://github.com/yast/aytests-tests
 
 # Depends on the vars substitution in .linuxrc files.
-Recommends:     aytests >= 1.0.7
+Recommends:     aytests >= 1.0.35
 
 %description
 Profiles and test scripts for AutoYaST2 integration tests.


### PR DESCRIPTION
To compress and download YaST2 logs, it's needed to install `tar`. We're not using `save_y2logs` because it's part of YaST and, in some scenarios, we don't have installed.