### PR TITLE
Move or sync profiles and verification scripts

### DIFF
--- a/aytests/bug-870820.list
+++ b/aytests/bug-870820.list
@@ -1,0 +1,1 @@
+bug-870820.sh                # Verify that  linuxrc creates ifcfg-INTERFACE files (bsc#870820)

--- a/aytests/bug-870820.rb
+++ b/aytests/bug-870820.rb
@@ -1,0 +1,5 @@
+require "aytests/spec_helper"
+
+describe "BSC#870820 regression test " do
+  include_examples "test_scripts", "Verify network config file names"
+end

--- a/aytests/bug-870820.sh
+++ b/aytests/bug-870820.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e -x
+
+# firewall disabled
+systemctl status SuSEfirewall2 | grep inactive
+
+#partitioning
+mount |grep /abuild
+
+
+grep "ENABLE_SYSRQ=.*yes.*" /etc/sysconfig/sysctl
+
+echo "AUTOYAST OK"

--- a/aytests/bug-870820.xml
+++ b/aytests/bug-870820.xml
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<!--  ****************** Doku ************************************************  http://www.suse.de/~ug/autoyast_doc/  http://forgeftp.novell.com//yast/doc/SL10.0/autoinstall/index.html  ************************************************************************-->
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!-- Bootloader {{{ -->
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <boot_boot>true</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>true</boot_mbr>
+      <boot_root>false</boot_root>
+      <debug>false</debug>
+      <generic_mbr>false</generic_mbr>
+      <hiddenmenu>false</hiddenmenu>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <sections config:type="list"/>
+  </bootloader>
+  <!-- }}} -->
+  <!-- Firewall {{{ -->
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <!-- }}} -->
+  <!-- General {{{ -->
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <forceboot config:type="boolean">false</forceboot>
+    </mode>
+    <mouse>
+      <id>probe</id>
+    </mouse>
+    <signature-handling/>
+  </general>
+  <!-- }}} -->
+  <!-- Inetd {{{ -->
+  <inetd>
+    <last_created config:type="integer">0</last_created>
+    <netd_service config:type="symbol">none</netd_service>
+    <netd_status config:type="integer">-1</netd_status>
+  </inetd>
+  <!-- }}} -->
+  <!-- Keyboard {{{ -->
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <!-- }}} -->
+  <!-- Language {{{ -->
+  <language>
+    <language>en_US</language>
+    <languages>en_US de_DE</languages>
+  </language>
+  <!-- }}} -->
+  <!-- Mail {{{ -->
+  <mail>
+    <aliases config:type="list">
+      <alias>
+        <alias>root</alias>
+        <destinations>arch-admins@suse.de</destinations>
+      </alias>
+    </aliases>
+    <connection_type config:type="symbol">permanent</connection_type>
+    <listen_remote config:type="boolean">false</listen_remote>
+    <masquerade_other_domains config:type="list">
+      <domain>suse.de</domain>
+    </masquerade_other_domains>
+    <mta config:type="symbol">postfix</mta>
+    <outgoing_mail_server>relay.suse.de</outgoing_mail_server>
+    <postfix_mda config:type="symbol">local</postfix_mda>
+    <use_amavis config:type="boolean">false</use_amavis>
+  </mail>
+  <!-- }}} -->
+  <!-- Networking {{{ -->
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <dhcp_resolv config:type="boolean">true</dhcp_resolv>
+    </dns>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ip_forward config:type="boolean">false</ip_forward>
+    </routing>
+  </networking>
+  <!-- }}} -->
+  <!-- NIS {{{ -->
+  <nis>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_by_dhcp config:type="boolean">true</nis_by_dhcp>
+    <nis_domain>suse.de</nis_domain>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_other_domains config:type="list">
+      <nis_other_domain>
+        <nis_broadcast config:type="boolean">false</nis_broadcast>
+        <nis_domain>suse.de</nis_domain>
+        <nis_servers config:type="list">
+          <nis_server>149.44.160.146</nis_server>
+          <nis_server>149.44.160.50</nis_server>
+        </nis_servers>
+      </nis_other_domain>
+    </nis_other_domains>
+    <start_autofs config:type="boolean">true</start_autofs>
+    <start_nis config:type="boolean">true</start_nis>
+  </nis>
+  <!-- }}} -->
+  <!-- NTP {{{ -->
+  <ntp-client>
+    <configure_dhcp config:type="boolean">false</configure_dhcp>
+    <peers config:type="list">
+      <peer>
+        <address>time.novell.com</address>
+        <initial_sync config:type="boolean">true</initial_sync>
+        <type>peer</type>
+      </peer>
+    </peers>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">true</start_in_chroot>
+  </ntp-client>
+  <!-- }}} -->
+  <!-- Partitioning {{{ -->
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <disklabel>gpt</disklabel>
+      <use>all</use>
+      <partitions config:type="list">
+        <partition>
+          <size>512MB</size>
+          <partition_nr config:type="integer">1</partition_nr>
+          <format config:type="boolean">false</format>
+          <partition_id config:type="integer">263</partition_id>
+        </partition>
+        <partition>
+          <mount>swap</mount>
+          <size>auto</size>
+          <partition_nr config:type="integer">2</partition_nr>
+        </partition>
+        <partition>
+          <size>30%</size>
+          <format config:type="boolean">false</format>
+          <partition_nr config:type="integer">3</partition_nr>
+        </partition>
+        <partition>
+          <mount>/</mount>
+          <label>SLES</label>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <size>30%</size>
+          <partition_nr config:type="integer">4</partition_nr>
+        </partition>
+        <partition>
+          <filesystem config:type="symbol">ext3</filesystem>
+          <label>ABUILD</label>
+          <mount>/abuild</mount>
+          <size>max</size>
+          <format config:type="boolean">true</format>
+          <partition_nr config:type="integer">5</partition_nr>
+        </partition>
+      </partitions>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">700</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">700</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">700</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">700</timeout>
+    </yesno_messages>
+  </report>
+  <!-- }}} -->
+  <!-- Runlevel {{{ -->
+  <runlevel>
+    <default>3</default>
+    <services config:type="list">
+      <service>
+        <service_name>SuSEfirewall2</service_name>
+        <service_status>disable</service_status>
+      </service>
+      <service>
+        <service_name>nfs</service_name>
+        <service_start>3 5</service_start>
+      </service>
+      <service>
+        <service_name>atd</service_name>
+        <service_start>3 5</service_start>
+      </service>
+      <service>
+        <service_name>nscd</service_name>
+        <service_status>disable</service_status>
+      </service>
+      <service>
+        <service_name>smartd</service_name>
+        <service_status>disable</service_status>
+      </service>
+      <service>
+        <service_name>sshd</service_name>
+        <service_status>enable</service_status>
+        <!-- <service_start>3 5</service_start> -->
+      </service>
+    </services>
+  </runlevel>
+  <!-- }}} -->
+  <!-- Scripts {{{ -->
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <!-- this script makes sure sshd gets started even if autoyast or systemd fail -->
+        <interpreter>shell</interpreter>
+        <debug config:type="boolean">true</debug>
+        <chrooted config:type="boolean">false</chrooted>
+        <source>
+          <![CDATA[
+          systemctl enable sshd && systemctl start sshd
+          ]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <!-- }}} -->
+  <!-- Software {{{  -->
+  <software xmlns:config="http://www.suse.com/1.0/configns">
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+    <packages config:type="list">
+      <package>grub2</package>
+      <package>nmap</package>
+      <package>emacs</package>
+      <package>mc</package>
+      <package>yast2-qt</package>
+      <package>bc</package>
+      <package>ipmitool</package>
+      <package>kdump</package>
+      <package>yast2-kdump</package>
+    </packages>
+  </software>
+  <!-- }}} -->
+  <!-- Sysconfig {{{ -->
+  <sysconfig config:type="list">
+    <sysconfig_entry>
+      <sysconfig_key>DHCLIENT_MODIFY_NIS_CONF</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/network/dhcp</sysconfig_path>
+      <sysconfig_value>yes</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>DHCLIENT_MODIFY_NTP_CONF</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/network/dhcp</sysconfig_path>
+      <sysconfig_value>yes</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>ENABLE_SYSRQ</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/sysctl</sysconfig_path>
+      <sysconfig_value>yes</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>HWCLOCK</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/clock</sysconfig_path>
+      <sysconfig_value>-u</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>MAX_DAYS_IN_TMP</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/cron</sysconfig_path>
+      <sysconfig_value>7</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>TMP_DIRS_TO_CLEAR</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/cron</sysconfig_path>
+      <sysconfig_value>/tmp /var/tmp</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>SOFTCORELIMIT</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/ulimit</sysconfig_path>
+      <sysconfig_value>unlimited</sysconfig_value>
+    </sysconfig_entry>
+    <sysconfig_entry>
+      <sysconfig_key>UPDATEDB_PRUNEPATHS</sysconfig_key>
+      <sysconfig_path>/etc/sysconfig/locate</sysconfig_path>
+      <sysconfig_value>/mnt /cdrom /tmp /usr/tmp /var/tmp /var/spool /proc /media /sys /abuild</sysconfig_value>
+    </sysconfig_entry>
+  </sysconfig>
+  <!-- }}} -->
+  <!-- Timezone {{{ -->
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <!-- }}} -->
+  <!-- User Defaults {{{ -->
+  <user_defaults>
+    <group>100</group>
+    <groups>video,dialout</groups>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+  </user_defaults>
+  <!-- }}} -->
+  <!-- Users {{{ -->
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <!-- }}} -->
+  <!-- {{{ Kdump -->
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>512M-2G:128M,2G-64G:256M,64G-:512M</crash_kernel>
+    <general>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_COPY_KERNEL>true</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>1</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO>arch-admins@suse.de</KDUMP_NOTIFICATION_TO>
+      <KDUMP_RUNLEVEL>1</KDUMP_RUNLEVEL>
+      <KDUMP_SAVEDIR>file:///abuild/dumps</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER>relay.suse.de</KDUMP_SMTP_SERVER>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>15</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <!-- }}} -->
+</profile>
+<!-- vim: set sw=2 ts=2 et ft=xml fdm=marker: :collapseFolds=1: -->

--- a/aytests/dns.list
+++ b/aytests/dns.list
@@ -1,0 +1,1 @@
+dns.sh                # dns server is running correctly

--- a/aytests/dns.rb
+++ b/aytests/dns.rb
@@ -1,0 +1,5 @@
+require "aytests/spec_helper"
+
+describe "DNS server " do
+  include_examples "test_scripts", "dns"
+end

--- a/aytests/dns.sh
+++ b/aytests/dns.sh
@@ -4,4 +4,13 @@ set -e -x
 systemctl start named
 nslookup cr01.openqa.local 127.0.0.1
 nslookup 172.16.0.10 127.0.0.1
+nslookup localhost 127.0.0.1
+# Ignore result as known issue bsc#1046605
+result=$(nslookup 127.0.0.1 127.0.0.1 || true)
+if [[ $result == *"** server can't find 1.0.0.127.in-addr.arpa: SERVFAIL"* ]]; then
+   echo "Expected error, see bsc#1046605: $result";
+else
+  return 1;
+fi
+
 echo "AUTOYAST OK"

--- a/aytests/dns.xml
+++ b/aytests/dns.xml
@@ -1,0 +1,1146 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+<!--
+  sets up a dns and tests it
+  via script run by autoyast_verify.pm
+  - custom local zones
+  - reverse dns mapping
+-->
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/sda</linux>
+      </device_map_entry>
+      <device_map_entry>
+        <firmware>hd1</firmware>
+        <linux>/dev/sdb</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <append>   resume=/dev/sda1 splash=silent quiet showopts</append>
+      <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append_failsafe>
+      <boot_boot>false</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>true</boot_root>
+      <default>0</default>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <os_prober>true</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">8</timeout>
+      <vgamode/>
+    </global>
+    <loader_type>grub2</loader_type>
+    <sections config:type="list"/>
+  </bootloader>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+
+
+<dns-server>
+  <allowed_interfaces config:type="list"/>
+  <chroot>1</chroot>
+  <logging config:type="list"/>
+  <options config:type="list">
+    <option>
+      <key>directory</key>
+      <value>"/var/lib/named"</value>
+    </option>
+    <option>
+      <key>disable-empty-zone</key>
+      <value>"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.IP6.ARPA"</value>
+    </option>
+    <option>
+      <key>dump-file</key>
+      <value>"/var/log/named_dump.db"</value>
+    </option>
+    <option>
+      <key>include</key>
+      <value>"/etc/named.d/forwarders.conf"</value>
+    </option>
+    <option>
+      <key>listen-on-v6</key>
+      <value>{ any; }</value>
+    </option>
+    <option>
+      <key>managed-keys-directory</key>
+      <value>"/var/lib/named/dyn/"</value>
+    </option>
+    <option>
+      <key>notify</key>
+      <value>no</value>
+    </option>
+    <option>
+      <key>statistics-file</key>
+      <value>"/var/log/named.stats"</value>
+    </option>
+    <option>
+      <key>forwarders</key>
+      <value/>
+    </option>
+  </options>
+  <start_service>0</start_service>
+  <use_ldap>0</use_ldap>
+  <zones config:type="list">
+    <listentry>
+      <file>root.hint</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>hint</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"root.hint"</value>
+	</option>
+      </options>
+      <type>hint</type>
+      <zone>.</zone>
+    </listentry>
+    <listentry>
+      <file>localhost.zone</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"localhost.zone"</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>localhost.</key>
+	  <type>NS</type>
+	  <value>@</value>
+	</listentry>
+	<listentry>
+	  <key>localhost.</key>
+	  <type>A</type>
+	  <value>127.0.0.1</value>
+	</listentry>
+	<listentry>
+	  <key>cx01</key>
+	  <type>A</type>
+	  <value>127.0.0.10</value>
+	</listentry>
+	<listentry>
+	  <key>cx01</key>
+	  <type>AAAA</type>
+	  <value>::1</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>6W</expiry>
+	<mail>root</mail>
+	<minimum>1W</minimum>
+	<refresh>2D</refresh>
+	<retry>4H</retry>
+	<serial>42</serial>
+	<server>@</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>1W</ttl>
+      <type>master</type>
+      <zone>localhost</zone>
+    </listentry>
+    <listentry>
+      <file>127.0.0.zone</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"127.0.0.zone"</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>0.0.127.in-addr.arpa.</key>
+	  <type>NS</type>
+	  <value>localhost.</value>
+	</listentry>
+	<listentry>
+	  <key>1</key>
+	  <type>PTR</type>
+	  <value>localhost.</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>6W</expiry>
+	<mail>root.localhost.</mail>
+	<minimum>1W</minimum>
+	<refresh>2D</refresh>
+	<retry>4H</retry>
+	<serial>42</serial>
+	<server>localhost.</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>1W</ttl>
+      <type>master</type>
+      <zone>0.0.127.in-addr.arpa</zone>
+    </listentry>
+    <listentry>
+      <file>127.0.0.zone</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"127.0.0.zone"</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.</key>
+	  <type>NS</type>
+	  <value>localhost.</value>
+	</listentry>
+	<listentry>
+	  <key>1</key>
+	  <type>PTR</type>
+	  <value>localhost.</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>6W</expiry>
+	<mail>root.localhost.</mail>
+	<minimum>1W</minimum>
+	<refresh>2D</refresh>
+	<retry>4H</retry>
+	<serial>42</serial>
+	<server>localhost.</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>1W</ttl>
+      <type>master</type>
+      <zone>0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa</zone>
+    </listentry>
+    <listentry>
+      <file>master/openqa.local</file>
+      <options config:type="list">
+	<option>
+	  <key>allow-transfer</key>
+	  <value>{ any; }</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"master/openqa.local"</value>
+	</option>
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>openqa.local.</key>
+	  <type>NS</type>
+	  <value>dns</value>
+	</listentry>
+	<listentry>
+	  <key>dns</key>
+	  <type>A</type>
+	  <value>127.0.0.1</value>
+	</listentry>
+	<listentry>
+	  <key>qahost</key>
+	  <type>A</type>
+	  <value>172.16.0.1</value>
+	</listentry>
+	<listentry>
+	  <key>cr01</key>
+	  <type>A</type>
+	  <value>172.16.0.10</value>
+	</listentry>
+	<listentry>
+	  <key>cr02</key>
+	  <type>A</type>
+	  <value>172.16.0.11</value>
+	</listentry>
+	<listentry>
+	  <key>crA</key>
+	  <type>CNAME</type>
+	  <value>cr02</value>
+	</listentry>
+	<listentry>
+	  <key>cr03</key>
+	  <type>A</type>
+	  <value>172.16.0.12</value>
+	</listentry>
+	<listentry>
+	  <key>crb</key>
+	  <type>CNAME</type>
+	  <value>cr01</value>
+	</listentry>
+	<listentry>
+	  <key>crA2</key>
+	  <type>CNAME</type>
+	  <value>crA</value>
+	</listentry>
+	<listentry>
+	  <key>crA3</key>
+	  <type>CNAME</type>
+	  <value>crA2</value>
+	</listentry>
+	<listentry>
+	  <key>crx</key>
+	  <type>CNAME</type>
+	  <value>crA</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>1w</expiry>
+	<mail>root</mail>
+	<minimum>1d</minimum>
+	<refresh>3h</refresh>
+	<retry>1h</retry>
+	<serial>2014092500</serial>
+	<server>@</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>2d</ttl>
+      <type>master</type>
+      <zone>openqa.local</zone>
+    </listentry>
+    <listentry>
+      <file>master/0.16.172.in-addr.arpa</file>
+      <options config:type="list">
+	<option>
+	  <key>allow-transfer</key>
+	  <value>{ any; }</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"master/0.16.172.in-addr.arpa"</value>
+	</option>
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>0.16.172.in-addr.arpa.</key>
+	  <type>NS</type>
+	  <value>dns.openqa.local.</value>
+	</listentry>
+	<listentry>
+	  <key>1.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>qahost.</value>
+	</listentry>
+	<listentry>
+	  <key>10.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>cr01.openqa.local.</value>
+	</listentry>
+	<listentry>
+	  <key>11.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>cr02.openqa.local.</value>
+	</listentry>
+	<listentry>
+	  <key>12.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>cr03.openqa.local.</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>1W</expiry>
+	<mail>1341414.</mail>
+	<minimum>1D</minimum>
+	<refresh>3H</refresh>
+	<retry>1H</retry>
+	<serial>2014092500</serial>
+	<server>xtest.</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>2D</ttl>
+      <type>master</type>
+      <zone>0.16.172.in-addr.arpa</zone>
+    </listentry>
+  </zones>
+</dns-server>
+
+
+
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>498</gid>
+      <group_password>x</group_password>
+      <groupname>sshd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>496</gid>
+      <group_password>x</group_password>
+      <groupname>polkitd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>54</gid>
+      <group_password>x</group_password>
+      <groupname>lock</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>495</gid>
+      <group_password>x</group_password>
+      <groupname>nscd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>499</gid>
+      <group_password>x</group_password>
+      <groupname>messagebus</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">false</encrypted>
+      <gid>497</gid>
+      <group_password>x</group_password>
+      <groupname>tape</groupname>
+      <userlist/>
+    </group>
+  </groups>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>176M-:88M</crash_kernel>
+    <general>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <networking>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <resolv_conf_policy/>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <broadcast>127.255.255.255</broadcast>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">false</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy/>
+    <http_proxy/>
+    <https_proxy/>
+    <no_proxy>localhost, 127.0.0.1</no_proxy>
+    <proxy_password/>
+    <proxy_user/>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+    <timeout config:type="integer">7</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <runlevel>
+  <default_target>multi-user</default_target>
+ <services config:type="list"/>
+  </runlevel>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services config:type="list"/>
+  </services-manager>
+  <software>
+    <image/>
+    <instsource/>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+    </patterns>
+    <packages config:type="list">
+      <package>bind</package>
+   </packages>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+  </suse_register>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>America/New_York</timezone>
+  </timezone>
+  <user_defaults>
+    <expire/>
+    <group>100</group>
+    <groups/>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <no_groups config:type="boolean">true</no_groups>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+                <user>
+                   <fullname>Bernhard M. Wiedemann</fullname>
+                   <encrypted config:type="boolean">false</encrypted>
+                   <user_password>nots3cr3t</user_password>
+                   <username>bernhard</username>
+                </user>
+
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>user</fullname>
+      <gid>100</gid>
+      <home>/home/user</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>user</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>499</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>499</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>User for nscd</fullname>
+      <gid>495</gid>
+      <home>/run/nscd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>496</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>nscd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>498</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>498</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>user for rpcbind</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>495</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>rpc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>User for polkitd</fullname>
+      <gid>496</gid>
+      <home>/var/lib/polkit</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>497</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>polkitd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>wwwrun</username>
+    </user>
+  </users>
+</profile>

--- a/aytests/ftp.xml
+++ b/aytests/ftp.xml
@@ -1,102 +1,18 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <!-- These are not supported anymore; bug 925381 -->
-  <sshd>
-    <x config:type="boolean">false</x>
-  </sshd>
-  <autofs>
-    <x config:type="boolean">false</x>
-  </autofs>
-  <restore>
-    <x config:type="boolean">false</x>
-  </restore>
-
+  <!--  sets up an ftp server,  test it via script run by autoyast_verify.pm  - default, anonymous access configuration-->
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
   <general>
     <mode>
       <confirm config:type="boolean">false</confirm>
     </mode>
-    <signature-handling>
-      <accept_unknown_gpg_key>
-        <all config:type="boolean">true</all>
-      </accept_unknown_gpg_key>
-    </signature-handling>
   </general>
-  <scripts>
-    <init-scripts config:type="list">
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <interpreter>shell</interpreter>
-        <source><![CDATA[
-  chkconfig sshd on
-  rcsshd start
-]]></source>
-      </script>
-    </init-scripts>
-  </scripts>
   <networking>
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
-  <report>
-    <errors>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <!-- Error popup of not supported YaST modules must disapper
-        after 10 seconds in order not stopping the installation. Bug 925381 -->
-      <timeout config:type="integer">10</timeout>
-    </errors>
-    <messages>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
-    </messages>
-    <warnings>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
-    </warnings>
-    <yesno_messages>
-      <log config:type="boolean">true</log>
-      <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
-    </yesno_messages>
-  </report>
-
-  <software>
-    <patterns config:type="list">
-      <pattern>Minimal</pattern>
-      <pattern>base</pattern>
-    </patterns>
-    <packages config:type="list">
-      <package>xinetd</package>
-      <package>vsftpd</package>
-    </packages>
-  </software>
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
-  <users config:type="list">
-    <user>
-      <encrypted config:type="boolean">false</encrypted>
-      <fullname>vagrant</fullname>
-      <gid>100</gid>
-      <home>/home/vagrant</home>
-      <shell>/bin/bash</shell>
-      <uid>1000</uid>
-      <user_password>nots3cr3t</user_password>
-      <username>vagrant</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">false</encrypted>
-      <fullname>root</fullname>
-      <gid>0</gid>
-      <home>/root</home>
-      <shell>/bin/bash</shell>
-      <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
-      <username>root</username>
-    </user>
-  </users>
   <ftp-server>
     <AnonAuthen>2</AnonAuthen>
     <AnonCreatDirs>NO</AnonCreatDirs>
@@ -144,4 +60,28 @@
     </netd_conf>
     <netd_status config:type="boolean">true</netd_status>
   </inetd>
+  <software>
+    <image/>
+    <instsource/>
+    <packages config:type="list">
+      <package>xinetd</package>
+      <package>vsftpd</package>
+    </packages>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+  </suse_register>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
 </profile>

--- a/aytests/lvm.list
+++ b/aytests/lvm.list
@@ -1,5 +1,4 @@
 lvm.sh                   # creates lvm partitions
-keyboard.sh              # sets default keyboard (bnc#891808)
 ntp.sh                   # sets peer/restrict in autoinst.xml by using default ntp.conf (bnc#928987)
 firewall.sh              # sets firewall with existing network (keep_install_network) (bnc#897129)
 installation_snapshot.sh # snapshot has been created

--- a/aytests/lvm.xml
+++ b/aytests/lvm.xml
@@ -140,11 +140,6 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     </remove-packages>
   </software>
 
-  <language>
-    <language>de_DE</language>
-    <languages>de_DE</languages>
-  </language>
-
   <users config:type="list">
     <user>
       <encrypted config:type="boolean">false</encrypted>

--- a/aytests/lvm_auto.list
+++ b/aytests/lvm_auto.list
@@ -2,3 +2,4 @@ lvm.sh                   # creates lvm partitions
 lvm_auto.sh              # switching auto to max option (bnc#962238)
 ca_mgm.sh                # checking ca-management error (bnc#962328)
 set_passwords.sh         # password are set (bsc#973639, bsc#974220, bsc#971804 and bsc#965852)
+keyboard.sh              # sets default keyboard (bnc#891808)


### PR DESCRIPTION
As part of improvement of autoyast tests, we want to keep profiles and
verification scripts in single place. As same profiles are used for
integration tests, we move them to aytests repository.
Whereas, as some files were forked, we need to sync them, to be on the
same side. After merging these changes, settings of relevant jobs have
to be changed. There will be another merge required for
os-autoinst-distri-opensuse repository.

@schubi2 please review if there is any issues to run these in your setup.
ftp profile mainly has changes in formatting, and only 2 settings were changes.
For lvm, somehow openQA is not capable of other layouts than default and for example instead of ";" we print a umlaut.

Changes to openQA distri repo are suggested in [PR#3358](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3358)