### PR TITLE
Do not remove default /etc/hosts entries (bsc#1039851)

### DIFF
--- a/aytests/hosts_setup.sh
+++ b/aytests/hosts_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+FILE=/etc/hosts
+
+fgrep -q "h063uz.pnet.ch h063uz" $FILE
+fgrep -q "sle15.suse.de" $FILE
+fgrep -q "sle13.suse.de" $FILE
+
+# Check one of the IPv6 default entries (bsc#1039851)
+grep "ff02::3[[:space:]]\+ipv6-allhosts" $FILE
+
+echo "AUTOYAST OK"

--- a/aytests/sles12_network.list
+++ b/aytests/sles12_network.list
@@ -18,3 +18,4 @@ udev_net_rules.sh              # Check udev network rules were written (bsc#9566
 set_passwords.sh               # password are set (bsc#973639, bsc#974220, bsc#971804 and bsc#965852)
 btrfs_empty_subvol_default_name.sh # default subvolume name is not set (FATE#317775)
 no_release_notes.sh            # release notes are not downloaded for AY (bsc#1009276)
+hosts_setup.sh                 # /etc/hosts updated according the profile

--- a/aytests/sles12_network.xml
+++ b/aytests/sles12_network.xml
@@ -638,6 +638,29 @@ ls -l /mnt/$BASE
       </rule>
     </net-udev>
   </networking>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>1.1.1.1</host_address>
+        <names config:type="list">
+          <name>h063uz.pnet.ch h063uz</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>2.2.2.2</host_address>
+        <names config:type="list">
+          <name>sle15.suse.de</name>
+          <name>sle13.suse.de</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
   <tftp-server>
     <start_tftpd config:type="boolean">true</start_tftpd>
     <tftp_directory>/srv/tftpboot</tftp_directory>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 31 12:37:54 UTC 2017 - knut.anderssen@suse.com
+
+- Check that default host entries are not removed from /etc/hosts
+  (bsc#1039851)
+- 1.1.16
+
+-------------------------------------------------------------------
 Wed Jul 19 10:22:21 CEST 2017 - schubi@suse.de
 
 - Added syslinux to package selection of sles12_network test.

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.1.15
+Version:        1.1.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Tested manually, it should pass once the new package be in the update repository.

- trello card: https://trello.com/c/OWAkiSkH/1089-5-important-betasles12-sp3-1039851-network-settings-incorrect-after-unattended-installation