### PR TITLE
Test for write and export root ssh authorized keys properly (bsc#bsc#1066342)

### DIFF
--- a/aytests/authorized_keys.sh
+++ b/aytests/authorized_keys.sh
@@ -21,8 +21,8 @@ test "$STAT" == "$USER 600"
 
 # Check root ssh authorized keys content
 grep "root@localhost.net" $ROOT_AUTHORIZED_KEYS
-ROOT_KEYS=`wc -l $ROOT_AUTHORIZED_KEYS | cut -f1 -d " "`
-test $ROOT_KEYS -eq 1
+# Vagrant adds its own key and it is present when the test run
+test $ROOT_KEYS -eq 2
 
 # Check root ssh authorized keys owner and permissios
 STAT=`stat -c '%U %a' $ROOT_AUTHORIZED_KEYS`

--- a/aytests/authorized_keys.sh
+++ b/aytests/authorized_keys.sh
@@ -7,6 +7,8 @@ set -e -x
 USER="suse"
 AUTHORIZED_KEYS="/home/$USER/.ssh/authorized_keys"
 PROFILE="/root/autoinst.xml"
+# Check that root ssh authorized keys are written an exported
+ROOT_AUTHORIZED_KEYS="/root/.ssh/authorized_keys"
 
 # Check content
 grep "vagrant@localhost.net" $AUTHORIZED_KEYS
@@ -17,7 +19,19 @@ test $KEYS -eq 1
 STAT=`stat -c '%U %a' $AUTHORIZED_KEYS`
 test "$STAT" == "$USER 600"
 
+# Check root ssh authorized keys content
+grep "root@localhost.net" $ROOT_AUTHORIZED_KEYS
+ROOT_KEYS=`wc -l $ROOT_AUTHORIZED_KEYS | cut -f1 -d " "`
+test $ROOT_KEYS -eq 1
+
+# Check root ssh authorized keys owner and permissios
+STAT=`stat -c '%U %a' $ROOT_AUTHORIZED_KEYS`
+test "$STAT" == "root 600"
+
 # Check that authorized_keys is present in the exported profile
 grep "authorized_keys" $PROFILE
+
+# Check that root ssh authorized keys are exported
+grep "lvjKyz root@localhost.net" $ROOT_AUTHORIZED_KEYS
 
 echo "AUTOYAST OK"

--- a/aytests/authorized_keys.sh
+++ b/aytests/authorized_keys.sh
@@ -21,8 +21,8 @@ test "$STAT" == "$USER 600"
 
 # Check root ssh authorized keys content
 grep "root@localhost.net" $ROOT_AUTHORIZED_KEYS
-# Vagrant adds its own key and it is present when the test run
-test $ROOT_KEYS -eq 2
+ROOT_KEYS=`wc -l $ROOT_AUTHORIZED_KEYS | cut -f1 -d " "`
+test $ROOT_KEYS -eq 1
 
 # Check root ssh authorized keys owner and permissios
 STAT=`stat -c '%U %a' $ROOT_AUTHORIZED_KEYS`

--- a/aytests/sles12.xml
+++ b/aytests/sles12.xml
@@ -861,6 +861,10 @@ ls -l /mnt/$BASE
       <uid>0</uid>
       <user_password>nots3cr3t</user_password>
       <username>root</username>
+      <authorized_keys config:type="list">
+        <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDgGEFlxgUo8jQjYPYI7DUm/tua/tmjGPhCnmqbk855SoHg9xEXLLJZ+bSePnPywDS901bzo0IiAwKky0r3RP6DJJkL0SPcwBlNxIuEq++nRwaGDOdoF5fwr3VXuYcHN02AARmUeb2WI4m7KNm6yG9MQOjKhmqYQDRbO65GuLEMA8fKaxMN5VyFqXIqVgXIhNv7z0NEUz31PUSaGywjqVlrSO/GLdY8xd8n4Aw/QL1xE3z1rZqfA0qRLnshHa+sZBALOxEmrbJdskBEreCA2krwCKI1hOp9cWASlmMjQbNbOQ3wLD+rs8MDc37zOD/U5LQzVbwF1Bg/ZJzde/lvjKyz root@localhost.net</authorized_key>
+        <authorized_key>non valid root ssh key</authorized_key>
+      </authorized_keys>
     </user>
   </users>
 

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 28 11:21:04 UTC 2017 - knut.anderssen@suse.com
+
+- Check that ssh authorized keys for root are written and exported
+  correctly (bsc#1066342)
+- 1.1.20
+
+-------------------------------------------------------------------
 Tue Oct 10 14:13:39 CEST 2017 - schubi@suse.de
 
 - The user has defined that no subvolumes will be created.

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.1.19
+Version:        1.1.20
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/H5k6VobD/1260-3-mu-sle-12-authorized-keys-ay-need-to-work-for-all-users-including-root)
- Test for yast/yast-users#150

The test will faile because current postinstall.sh script overwrites /root/.ssh/authorized_keys file, so we are discussing how to add the less intrusive way to solve it.