### PR TITLE
Fix test for root authorized_keys file (bsc#1075830)

### DIFF
--- a/aytests/authorized_keys.sh
+++ b/aytests/authorized_keys.sh
@@ -8,7 +8,7 @@ USER="suse"
 AUTHORIZED_KEYS="/home/$USER/.ssh/authorized_keys"
 PROFILE="/root/autoinst.xml"
 # Check that root ssh authorized keys are written and exported
-ROOT_AUTHORIZED_KEYS="/root/.ssh/authorized_keys"
+ROOT_AUTHORIZED_KEYS="/root/.ssh/authorized_keys.aytests"
 
 # Check content
 grep "vagrant@localhost.net" $AUTHORIZED_KEYS

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 16 14:10:32 UTC 2018 - knut.anderssen@suse.com
+
+- Fix test for root ssh authorized_keys file once the postinstall
+  script moves the file to authorized_keys.aytests (bsc#1075830).
+- 1.2.14
+
+-------------------------------------------------------------------
 Mon Jan 15 10:50:31 CET 2018 - schubi@suse.de
 
 - Moved sles12 test to general sles test.

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.2.13
+Version:        1.2.14
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The postinstall.sh script was modified to move the authorized_keys file preventing the replacement by the vagrant own ssh key but the test was not updated, this PR fix that issue.

- https://github.com/yast/autoyast-integration-test/pull/146/files#diff-77842097869985f378b7c28445f407afR15