### PR TITLE
Fixed SuSEFirewall2 based profile

### DIFF
--- a/aytests/sles15_suse_firewall.xml
+++ b/aytests/sles15_suse_firewall.xml
@@ -16,8 +16,8 @@
   </deploy_image>
   <firewall>
     <FW_DEV_EXT>eth0</FW_DEV_EXT>
+    <FW_DEV_DMZ>any</FW_DEV_DMZ>
     <FW_CONFIGURATIONS_EXT>apache2 apache2-ssl sshd</FW_CONFIGURATIONS_EXT>
-    <FW_CONFIGURATIONS_DMZ>any</FW_CONFIGURATIONS_EXT>
     <FW_SERVICES_EXT_TCP>8080</FW_SERVICES_EXT_TCP>
     <FW_SERVICES_EXT_UDP>9090</FW_SERVICES_EXT_UDP>
     <enable_firewall config:type="boolean">true</enable_firewall>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 17 17:11:29 UTC 2018 - knut.anderssen@suse.com
+
+- Fixed SuSEFirewall2 based profile (fate#323460)
+- 1.2.16
+
+-------------------------------------------------------------------
 Wed Jan 17 15:39:04 CET 2018 - schubi@suse.de
 
 - Adapting upgrade to SLES15.

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.2.15
+Version:        1.2.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The definition of DMZ interfaces added in this PR is not correct:

https://github.com/yast/aytests-tests/pull/110/files#diff-a3591e8a74f9e11b941bf43da2c4e637R20

The tag should be FW_DEV_DMZ and should be closed correctly.