### PR TITLE
disabling pam_nologin module while installation

### DIFF
--- a/aytests/sles.xml
+++ b/aytests/sles.xml
@@ -250,6 +250,12 @@ touch /rebootflag
 ls -l $BASE
 mv $BASE /mnt/$BASE
 ls -l /mnt/$BASE
+# While installation some files will be copied to system by the
+# user vagrant. The pam module pam_nologin is blocking these scp
+# calls because it does not allow login while installation by a
+# none root user. So we are disabling pam_nologin while calling the
+# second stage.
+sed -i.bak '/pam_nologin/d' /mnt/etc/pam.d/sshd
         ]]></source>
       <chrooted config:type="boolean">false</chrooted>
 

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 22 17:09:14 CET 2018 - schubi@suse.de
+
+- Disabling pam_nologin while installing an image.
+- 1.2.17
+
+-------------------------------------------------------------------
 Wed Jan 17 17:11:29 UTC 2018 - knut.anderssen@suse.com
 
 - Fixed SuSEFirewall2 based profile (fate#323460)

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.2.16
+Version:        1.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Please review the following changes:
  * 5ef42b0 disabling pam_nologin while installing an image
