### PR TITLE
Remove xinetd package from tftp profile

### DIFF
--- a/aytests/tftp.xml
+++ b/aytests/tftp.xml
@@ -143,7 +143,6 @@ chmod 755 /srv/tftpboot
       <pattern>minimal_base</pattern>
     </patterns>
     <packages config:type="list">
-      <package>xinetd</package>
       <package>tftp</package>
     </packages>
     <products config:type="list">


### PR DESCRIPTION
Josef has adjusted tftp to use systemd sockets instead of xinetd. As of
now profile fails to find xinetd package, other than that no adjustments
are required.