### PR TITLE
Adjust tftp for chrony

### DIFF
--- a/aytests/ntp_conf.sh
+++ b/aytests/ntp_conf.sh
@@ -2,6 +2,6 @@
 
 set -e -x
 
-grep "server ntp.suse.de iburst" /etc/ntp.conf
-grep "driftfile /var/lib/ntp/drift/ntp.drift" /etc/ntp.conf
+grep "pool ntp.suse.de iburst" /etc/chrony.conf
+grep "driftfile /var/lib/chrony/drift" /etc/chrony.conf
 echo "AUTOYAST OK"

--- a/aytests/tftp.xml
+++ b/aytests/tftp.xml
@@ -185,6 +185,13 @@ chmod 755 /srv/tftpboot
 
   <ntp-client>
     <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+        <ntp_server>
+            <address>ntp.suse.de</address>
+            <iburst config:type="boolean">true</iburst>
+            <offline config:type="boolean">false</offline>
+        </ntp_server>
+    </ntp_servers>
   </ntp-client>
 
 </profile>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 22 12:17:07 UTC 2018 - riafarov@suse.com
+
+- Adjust tftp test for chrony
+- 1.2.27
+
+-------------------------------------------------------------------
 Thu Feb 22 09:58:17 UTC 2018 - igonzalezsosa@suse.com
 
 - Test whether AutoYaST is able to determine the proper filesystem


### PR DESCRIPTION
tftp test suite fails as we run ntp_conf check which expects different configuration. So we need to adjust shell script and profile to match.