### PR TITLE
Adjust lvm ay test for ntp and firewall changes

### DIFF
--- a/aytests/lvm.list
+++ b/aytests/lvm.list
@@ -1,5 +1,4 @@
 lvm.sh                   # creates lvm partitions
-ntp.sh                   # sets peer/restrict in autoinst.xml by using default ntp.conf (bnc#928987)
 firewall.sh              # sets firewall with existing network (keep_install_network) (bnc#897129)
 installation_snapshot.sh # snapshot has been created
 btrfs_snapshots.sh       # creates @/. snapshots on LVM (bnc#935858)

--- a/aytests/lvm.xml
+++ b/aytests/lvm.xml
@@ -64,17 +64,9 @@ mv /var/run/zypp.sav /var/run/zypp.pid
       <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
   <firewall>
-    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
-    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
-    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
     <FW_CONFIGURATIONS_EXT>apache2 apache2-ssl</FW_CONFIGURATIONS_EXT>
-    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
-    <FW_IGNORE_FW_BROADCAST_EXT>no</FW_IGNORE_FW_BROADCAST_EXT>
-    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
-    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
     <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
     <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
-    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
     <FW_SERVICES_EXT_TCP>8080</FW_SERVICES_EXT_TCP>
     <FW_SERVICES_EXT_UDP>9090</FW_SERVICES_EXT_UDP>
     <enable_firewall config:type="boolean">false</enable_firewall>
@@ -157,7 +149,6 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     <packages config:type="list">
       <package>sudo</package>
       <package>yast2-ntp-client</package>
-      <package>ntp</package>
       <package>apache2</package>
       <package>apache2-prefork</package>
     </packages>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 28 12:39:39 UTC 2018 - riafarov@suse.com
+
+- Adjust lvm ay test for ntp and firewall changes
+- 1.2.28
+
+-------------------------------------------------------------------
 Wed Feb 22 12:17:07 UTC 2018 - riafarov@suse.com
 
 - Adjust tftp test for chrony

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.2.26
+Version:        1.2.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Due to changes in product now we don't have ntp package available, as
well as some firewall options are not supported anymore.
Ntp test doesn't make sense, need to clarify what is expected for chrony
now (see [bsc#1082592](https://bugzilla.suse.com/show_bug.cgi?id=1082592)).