### PR TITLE
 Adapted btrfs_snapshots.sh to fstab changes 

### DIFF
--- a/aytests/btrfs_snapshots.sh
+++ b/aytests/btrfs_snapshots.sh
@@ -6,7 +6,7 @@ set -e -x
 
 btrfs subvolume list / | grep '@/.snapshots' && SUBVOLUME_EXISTS=1
 
-grep '/\.snapshots .*subvol=@/\.snapshots' /etc/fstab && SUBVOLUME_IN_FSTAB=1
+grep '/\.snapshots .*subvol=/@/\.snapshots' /etc/fstab && SUBVOLUME_IN_FSTAB=1
 
 if [ "${SUBVOLUME_EXISTS}" == "1" ] && [ "${SUBVOLUME_IN_FSTAB}" == "1"  ]; then
   echo "AUTOYAST OK"

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 26 15:33:12 UTC 2018 - cwh@suse.com
+
+- Adapted btrfs_snapshots.sh to the new format used in fstab.
+- 1.2.34
+
+-------------------------------------------------------------------
 Mon Mar 12 14:57:40 CET 2018 - schubi@suse.de
 
 - Removed profile_sections.sh from sles_network.rb test due missing

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.2.33
+Version:        1.2.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Fixing https://openqa.suse.de/tests/1515343#step/autoyast_verify/9
from poo#32704