### PR TITLE
Remove FW_LOG_ACCEPT_CRIT option from lvm profile

### DIFF
--- a/aytests/lvm.xml
+++ b/aytests/lvm.xml
@@ -65,7 +65,6 @@ mv /var/run/zypp.sav /var/run/zypp.pid
   </networking>
   <firewall>
     <FW_CONFIGURATIONS_EXT>apache2 apache2-ssl</FW_CONFIGURATIONS_EXT>
-    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
     <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
     <FW_SERVICES_EXT_TCP>8080</FW_SERVICES_EXT_TCP>
     <FW_SERVICES_EXT_UDP>9090</FW_SERVICES_EXT_UDP>

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  3 06:54:16 UTC 2018 - riafarov@suse.com
+
+- Remove FW_LOG_ACCEPT_CRIT from lvm profile
+- 1.2.35
+
+-------------------------------------------------------------------
 Mon Mar 26 15:33:12 UTC 2018 - cwh@suse.com
 
 - Adapted btrfs_snapshots.sh to the new format used in fstab.

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -15,9 +15,8 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-
 Name:           aytests-tests
-Version:        1.2.34
+Version:        1.2.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
FW_LOG_ACCEPT_CRIT SuSEfirewall option is not supported anymore, so
removing it from the profile.