### PR TITLE
Use variable MSG_TIMEOUT to set timeout parameters for messages

### DIFF
--- a/aytests/lvm.vars
+++ b/aytests/lvm.vars
@@ -1,0 +1,1 @@
+MSG_TIMEOUT=5

--- a/aytests/lvm.xml
+++ b/aytests/lvm.xml
@@ -61,22 +61,22 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </messages>
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </warnings>
     <yesno_messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </yesno_messages>
   </report>
 

--- a/aytests/tftp.vars
+++ b/aytests/tftp.vars
@@ -1,1 +1,2 @@
 POST_SCRIPT_URL=http://{{IP}}:{{PORT}}/static/scripts/post_script.sh
+MSG_TIMEOUT=5

--- a/aytests/tftp.xml
+++ b/aytests/tftp.xml
@@ -99,22 +99,22 @@ chmod 755 /srv/tftpboot
       <show config:type="boolean">true</show>
       <!-- Error popup of not supported YaST modules must disapper
         after 10 seconds in order not stopping the installation. Bug 925381 -->
-      <timeout config:type="integer">10</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </messages>
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </warnings>
     <yesno_messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">5</timeout>
+      <timeout config:type="integer">{{MSG_TIMEOUT}}</timeout>
     </yesno_messages>
   </report>
 

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  5 14:38:25 UTC 2018 - riafarov@suse.com
+
+- Use variable for the timeout of AY messages in lvm and tftp profiles
+- 1.1.21
+
+-------------------------------------------------------------------
 Tue Nov 28 11:21:04 UTC 2017 - knut.anderssen@suse.com
 
 - Check that ssh authorized keys for root are written and exported

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -17,7 +17,7 @@
 
 
 Name:           aytests-tests
-Version:        1.1.20
+Version:        1.1.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Same changes for sle12 as were done in [Adjust lvm and tftp profiles for SLE15 #111](https://github.com/yast/aytests-tests/pull/111/files)
[poo#37015](https://progress.opensuse.org/issues/37015)