### PR TITLE
Look for unsupported sections message in all log files

### DIFF
--- a/aytests/unsupported_modules.sh
+++ b/aytests/unsupported_modules.sh
@@ -2,4 +2,4 @@
 
 set -e -x
 zgrep "Could not process these unsupported profile sections: \[\"autofs\", \"restore\", \"sshd\"\]"\
- /var/log/YaST2/y2log-1.gz && echo "AUTOYAST OK"
+ /var/log/YaST2/* && echo "AUTOYAST OK"

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 29 12:03:25 UTC 2018 - riafarov@suse.com
+
+- Look for unsupported sections message in all log files
+- 1.1.22
+
+-------------------------------------------------------------------
 Thu Jul  5 14:38:25 UTC 2018 - riafarov@suse.com
 
 - Use variable for the timeout of AY messages in lvm and tftp profiles

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -15,9 +15,8 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-
 Name:           aytests-tests
-Version:        1.1.21
+Version:        1.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Fixes https://openqa.suse.de/tests/2007157#step/autoyast_verify/10 as we have Y2DEBUG option enabled, test fails as we have it in different wrapped log file.