### PR TITLE
Look for unsupported sections message in all log files

### DIFF
--- a/aytests/unsupported_modules.sh
+++ b/aytests/unsupported_modules.sh
@@ -2,4 +2,4 @@
 
 set -e -x
 zgrep "Could not process these unsupported profile sections: \[\"autofs\", \"restore\", \"sshd\"\]"\
- /var/log/YaST2/y2log-1.gz && echo "AUTOYAST OK"
+ /var/log/YaST2/* && echo "AUTOYAST OK"

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 30 07:33:44 UTC 2018 - riafarov@suse.com
+
+- Look for unsupported sections message in all log files
+- 1.2.39
+
+-------------------------------------------------------------------
 Tue May 15 16:51:31 CEST 2018 - schubi@suse.de
 
 - Timing issue in systemctl: Dalay of service start.

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           aytests-tests
-Version:        1.2.38
+Version:        1.2.39
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Same as for SLE 12 SP4, fix for https://openqa.suse.de/tests/2010421#step/autoyast_verify/10