### PR TITLE
Fix return code when searching entry in the yast logs

### DIFF
--- a/aytests/unsupported_modules.sh
+++ b/aytests/unsupported_modules.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 set -e -x
-zgrep "Could not process these unsupported profile sections: \[\"autofs\", \"restore\", \"sshd\"\]"\
- /var/log/YaST2/* && echo "AUTOYAST OK"
+[[ -n $(zgrep -l\
+            'Could not process these unsupported profile sections: \["autofs", "restore", "sshd"\]'\
+        /var/log/YaST2/y2log*) \
+]] && echo "AUTOYAST OK"

--- a/package/aytests-tests.changes
+++ b/package/aytests-tests.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  7 14:41:35 UTC 2018 - Rodion Iafarov <riafarov@suse.com>
+
+- Fix return code when searching entry in the yast logs
+- 1.1.23
+
+-------------------------------------------------------------------
 Wed Aug 29 12:03:25 UTC 2018 - riafarov@suse.com
 
 - Look for unsupported sections message in all log files

--- a/package/aytests-tests.spec
+++ b/package/aytests-tests.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           aytests-tests
-Version:        1.1.22
+Version:        1.1.23
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
zgrep returns non-zero code if was not able to find given expression in
the last file. Since we look in multiple logs files, actually only
one contains the change. Only case when it works fine, if the last file
matching wildcard contains the string.