### PR TITLE
Fix tftp server directory

### DIFF
--- a/aytests/tftp.xml
+++ b/aytests/tftp.xml
@@ -153,7 +153,7 @@ chmod 755 /srv/tftpboot
 
   <tftp-server>
     <start_tftpd config:type="boolean">true</start_tftpd>
-    <tftp_directory>/srv/tftpboot</tftp_directory>
+    <tftp_directory>/tftpboot</tftp_directory>
   </tftp-server>
 
   <!-- bug 868614 - empty services entry -->


### PR DESCRIPTION
According to documentation tftp directory should be: https://doc.opensuse.org/projects/autoyast/#idm139966594580288